### PR TITLE
Assign the PR that failed to be backported to the core dev.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,8 @@ Once the pull request has been merged, `@miss-islington <https://github.com/miss
 will prepare the backport PR.
 
 If `@miss-islington <https://github.com/miss-islington>`_ encountered any issue while backporting,
-it will leave a comment about it. The PR then needs to be backported manually.
+it will leave a comment about it, and the PR will be assigned to the core developer
+who merged the PR. The PR then needs to be backported manually.
 
 
 Merging the Backport PR

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -46,6 +46,7 @@ def backport_task(commit_hash, branch, *, issue_number, created_by, merged_by):
                                cherry_picker {commit_hash} {branch}
                                ```
                                """)
+            util.assign_pr_to_core_dev(issue_number, merged_by)
     cp = cherry_picker.CherryPicker('origin', commit_hash, [branch],
                                     prefix_commit=False)
     try:
@@ -58,6 +59,7 @@ def backport_task(commit_hash, branch, *, issue_number, created_by, merged_by):
                             cherry_picker {commit_hash} {branch}
                             ```
                             """)
+        util.assign_pr_to_core_dev(issue_number, merged_by)
         cp.abort_cherry_pick()
     except cherry_picker.CherryPickException:
         util.comment_on_pr(issue_number,
@@ -67,6 +69,7 @@ def backport_task(commit_hash, branch, *, issue_number, created_by, merged_by):
                             cherry_picker {commit_hash} {branch}
                             ```
                             """)
+        util.assign_pr_to_core_dev(issue_number, merged_by)
         cp.abort_cherry_pick()
 
 

--- a/miss_islington/util.py
+++ b/miss_islington/util.py
@@ -28,6 +28,28 @@ def comment_on_pr(issue_number, message):
         print(response.text)
 
 
+def assign_pr_to_core_dev(issue_number, coredev_login):
+    """
+    Assign the PR to a core dev.  Should be done when miss-islington failed
+    to backport.
+    """
+    request_headers = sansio.create_headers(
+        "miss-islington",
+        oauth_token=os.getenv('GH_AUTH'))
+    edit_issue_url = f"https://api.github.com/repos/python/cpython/issues/{issue_number}"
+    data = {
+        "assignees": [coredev_login],
+    }
+    response = requests.patch(edit_issue_url,
+                             headers=request_headers,
+                             json=data)
+    if response.status_code == requests.codes.created:
+        print(f"Assigned PR {issue_number} to {coredev_login}")
+    else:
+        print(response.status_code)
+        print(response.text)
+
+
 async def leave_comment(gh, pr_number, message):
     """
     Leave a comment on a PR/Issue


### PR DESCRIPTION
Update the readme indicating that the PR will be assigned to the
core dev for follow up.