### PR TITLE
Revert cherry_picker to 1.2.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cherry_picker==1.3.1
+cherry_picker==1.2.2
 aiohttp==3.5.4
 gidgethub==3.1.0
 cachetools==3.1.0


### PR DESCRIPTION
As I see a lot of changes between 1.2.2 and 1.3, I think we should start by reverting, and then take the time to understand what's going wrong.
see https://github.com/python/miss-islington/issues/219