### PR TITLE
miss-islington can also do regular non-backport merges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ miss-islington
 
 🐍🍒⛏🤖
 
-Bot for backporting `CPython <https://github.com/python/cpython/>`_ Pull Requests.
+Bot for backporting and merging `CPython <https://github.com/python/cpython/>`_ Pull Requests.
 
 miss-islington requires Python 3.6. Python 3.7 is not yet supported.
 
@@ -33,6 +33,15 @@ Merging the Backport PR
 
 If a Python core developer approved the backport PR made by miss-islington, it will be
 automatically merged once all the CI checks passed.
+
+
+Merging PRs
+===========
+
+If a Python core developer approved a PR made by anyone and added an "automerge" label,
+it will be autmatically merged once all the CI checks pass. This works for PRs from
+anyone.
+
 
 **Aside**: where does the name come from?
 =========================================

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,7 @@ Merging PRs
 ===========
 
 If a Python core developer approved a PR made by anyone and added an "automerge" label,
-it will be autmatically merged once all the CI checks pass. This works for PRs from
-anyone.
+it will be autmatically merged once all the CI checks pass.
 
 
 **Aside**: where does the name come from?

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ automatically merged once all the CI checks passed.
 Merging PRs
 ===========
 
-If a Python core developer approved a PR made by anyone and added an "automerge" label,
+If a Python core developer approved a PR made by anyone and added the "🤖 automerge" label,
 it will be autmatically merged once all the CI checks pass.
 
 


### PR DESCRIPTION
Add the information to README that miss-islington can also merge regular PRs if `automerge` label is added to them and it is approved by a Core Dev.