### PR TITLE
Use GH to signify Github handle of the user instead of "@".

### DIFF
--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -145,5 +145,5 @@ async def merge_pr(gh, pr, sha, is_automerge=False):
 
 async def add_automerged_by(gh, pr_data, username):
 
-    new_pr_body = f"{pr_data['body']}\n\nAutomerge-Triggered-By: @{username}"
+    new_pr_body = f"{pr_data['body']}\n\nAutomerge-Triggered-By: GH:{username}"
     await gh.patch(pr_data["url"], data={"body": new_pr_body})

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -1498,5 +1498,5 @@ async def test_automerge_label_triggered_by_added_to_pr():
     await status_change.router.dispatch(event, gh)
     assert gh.patch_url == f'{data["pull_request"]["url"]}'
     assert gh.patch_data == {
-        "body": f"{data['pull_request']['body']}\n\nAutomerge-Triggered-By: @Mariatta"
+        "body": f"{data['pull_request']['body']}\n\nAutomerge-Triggered-By: GH:Mariatta"
     }


### PR DESCRIPTION
"@" usually doesn't give any information about what exactly the handle means
since we don't know it is a Github handle from the commit message.

Changing the pattern to be `GH:` similar to what we do for Pull Requests
with (GH-).

Fixes #270