### PR TITLE
Use GH: rather than @ to tag core devs in Automerge-Triggered-By

### DIFF
--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -83,7 +83,7 @@ async def pr_unlabeled(event, gh, *args, **kwargs):
 
     body = event.data["pull_request"]["body"]
     url = event.data["pull_request"]["url"]
-    new_body = re.sub(rf"{AUTOMERGE_TRAILER}: @(\w|\-)+", "", body)
+    new_body = re.sub(rf"{AUTOMERGE_TRAILER}: (GH:|@)(\w|\-)+", "", body).rstrip()
     await gh.patch(url, data={"body": new_body})
 
 
@@ -178,5 +178,5 @@ async def merge_pr(gh, pr, sha, is_automerge=False):
 
 
 async def add_automerged_by(gh, pr_data, username):
-    new_pr_body = f"{pr_data['body']}\n\n{AUTOMERGE_TRAILER}: GH:{username}"
+    new_pr_body = f"{pr_data['body'].rstrip()}\n\n{AUTOMERGE_TRAILER}: GH:{username}"
     await gh.patch(pr_data["url"], data={"body": new_pr_body})

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -178,5 +178,5 @@ async def merge_pr(gh, pr, sha, is_automerge=False):
 
 
 async def add_automerged_by(gh, pr_data, username):
-    new_pr_body = f"{pr_data['body']}\n\n{AUTOMERGE_TRAILER}: @{username}"
+    new_pr_body = f"{pr_data['body']}\n\n{AUTOMERGE_TRAILER}: GH:{username}"
     await gh.patch(pr_data["url"], data={"body": new_pr_body})

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -1815,7 +1815,7 @@ async def test_automerge_label_removed_by_core_dev():
             "head": {"sha": sha},
             "number": 5547,
             "title": "bpo-32720: Fixed the replacement field grammar documentation.",
-            "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n\nAutomerge-Triggered-By: @miss-islington",
+            "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n\nAutomerge-Triggered-By: GH:miss-islington\n\nAutomerge-Triggered-By: @miss-islington",
             "url": "https://api.github.com/repos/python/cpython/pulls/5547",
             "issue_url": "https://api.github.com/repos/python/cpython/issues/5547",
         },
@@ -1854,6 +1854,8 @@ async def test_automerge_label_removed_by_core_dev():
     await status_change.router.dispatch(event, gh)
     assert "body" in gh.patch_data
     assert "Automerge-Triggered-By: @miss-islington" not in gh.patch_data["body"]
+    assert "Automerge-Triggered-By: GH:miss-islington" not in gh.patch_data["body"]
+    assert gh.patch_data["body"].endswith("`integer`.")
 
 
 async def test_automerge_label_removed_by_non_core_dev():

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -1801,7 +1801,7 @@ async def test_automerge_label_triggered_by_added_to_pr():
     await status_change.router.dispatch(event, gh)
     assert gh.patch_url == f'{data["pull_request"]["url"]}'
     assert gh.patch_data == {
-        "body": f"{data['pull_request']['body']}\n\nAutomerge-Triggered-By: @Mariatta"
+        "body": f"{data['pull_request']['body']}\n\nAutomerge-Triggered-By: GH:Mariatta"
     }
 
 


### PR DESCRIPTION
This is based on #275 (the first commit is the commit from #275, with corrected issue number in the commit message), and contains a minor missing fix from that PR.

Closes #270, supersedes #275.
