### PR TITLE
Fix the redis URL

### DIFF
--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -16,7 +16,8 @@ from . import util
 app = celery.Celery("backport_cpython")
 
 app.conf.update(
-    BROKER_URL=os.environ["HEROKU_REDIS_MAROON_TLS_URL"], CELERY_RESULT_BACKEND=os.environ["HEROKU_REDIS_MAROON_TLS_URL"]
+    BROKER_URL=os.environ["HEROKU_REDIS_MAROON_TLS_URL"],
+    CELERY_RESULT_BACKEND=os.environ["HEROKU_REDIS_MAROON_TLS_URL"],
 )
 
 cache = cachetools.LRUCache(maxsize=500)

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -16,7 +16,7 @@ from . import util
 app = celery.Celery("backport_cpython")
 
 app.conf.update(
-    BROKER_URL=os.environ["REDIS_URL"], CELERY_RESULT_BACKEND=os.environ["REDIS_URL"]
+    BROKER_URL=os.environ["HEROKU_REDIS_MAROON_TLS_URL"], CELERY_RESULT_BACKEND=os.environ["HEROKU_REDIS_MAROON_TLS_URL"]
 )
 
 cache = cachetools.LRUCache(maxsize=500)

--- a/tests/test_backport_pr.py
+++ b/tests/test_backport_pr.py
@@ -7,7 +7,7 @@ import pytest
 import redis
 import kombu
 
-os.environ["REDIS_URL"] = "someurl"
+os.environ["HEROKU_REDIS_MAROON_TLS_URL"] = "someurl"
 
 from miss_islington import backport_pr
 


### PR DESCRIPTION
We upgraded the redis environment on Heroku a couple days ago. In the new environment, the ``REDIS_URL`` environment variable was changed to ``HEROKU_REDIS_MAROON_TLS_URL``.
Updated the code where we were hardcoding it to the old to url.

Fixes #462 