### PR TITLE
Setup Sentry in the Celery worker

### DIFF
--- a/miss_islington/__main__.py
+++ b/miss_islington/__main__.py
@@ -5,9 +5,7 @@ import traceback
 
 import aiohttp
 import cachetools
-import sentry_sdk
 from aiohttp import web
-from sentry_sdk.integrations.celery import CeleryIntegration
 from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import routing, sansio
 
@@ -18,9 +16,6 @@ router = routing.Router(
 )
 
 cache = cachetools.LRUCache(maxsize=500)
-
-
-sentry_sdk.init(os.environ.get("SENTRY_DSN"), integrations=[CeleryIntegration()])
 
 
 async def main(request):

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -1,17 +1,18 @@
-import celery
 import asyncio
 import os
 import subprocess
+
 import aiohttp
-from gidgethub import aiohttp as gh_aiohttp
-
 import cachetools
-
-from celery import bootsteps
-
+import celery
 from cherry_picker import cherry_picker
+from celery import bootsteps
+from gidgethub import aiohttp as gh_aiohttp
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 from . import util
+
 
 app = celery.Celery("backport_cpython")
 
@@ -21,6 +22,8 @@ app.conf.update(
 )
 
 cache = cachetools.LRUCache(maxsize=500)
+sentry_sdk.init(os.environ.get("SENTRY_DSN"), integrations=[CeleryIntegration()])
+
 
 CHERRY_PICKER_CONFIG = {
     "team": "python",


### PR DESCRIPTION
This moves the CeleryIntegration setup to the Celery worker module. `__main__.py` isn't imported by the Celery worker so the integration wasn't working.