### PR TITLE
Fix incorrect success statement in status change comment

### DIFF
--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -133,13 +133,15 @@ async def check_ci_status_and_approval(
                         )
                     if success:
                         emoji = "✅"
+                        description = "success"
                     else:
                         emoji = "❌"
+                        description = "failure"
                     print("leaving a comment")
                     await util.leave_comment(
                         gh,
                         pr_number=pr_number,
-                        message=f"{participants}: Status check is done, and it's a {result['state']} {emoji} .",
+                        message=f"{participants}: Status check is done, and it's a {description} {emoji} .",
                     )
                 if success:
                     if util.pr_is_awaiting_merge(pr_for_commit["labels"]):


### PR DESCRIPTION
Fixes inconsistent statements such as [this one](https://github.com/python/cpython/pull/29669#issuecomment-974678543) [(more)](https://github.com/python/cpython/pulls?q=is%3Apr+is%3Aopen+%22success+%E2%9D%8C%22):

"it's a success ❌"

The `success` boolean was added in #382 without updating the message.