### PR TITLE
Don't check for "CLA signed" label.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+
+[report]
+fail_under = 100

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
 branch = True
+omit =
+    miss_islington/tasks.py
 
 [report]
 fail_under = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python3 -m pip install -U -r dev-requirements.txt
-      - run: python3 -m coverage run --branch -m pytest tests/
+      - run: pytest --cov=. --cov-report=xml
       - uses: codecov/codecov-action@v1
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python3 -m pip install -U -r dev-requirements.txt
       - run: pytest --cov=. --cov-report=xml
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/miss_islington/check_run.py
+++ b/miss_islington/check_run.py
@@ -24,11 +24,6 @@ async def check_run_completed(event, gh, *args, **kwargs):
         pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:
             pr_labels = pr_for_commit["labels"]
-            print("is auomer")
-            print(util.pr_is_automerge(pr_labels))
-            print(util.pr_is_awaiting_merge(pr_labels))
-            print("pr label")
-            print(pr_labels)
             if util.pr_is_automerge(pr_labels) and util.pr_is_awaiting_merge(pr_labels):
                 await check_ci_status_and_approval(
                     gh,

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -93,6 +93,7 @@ async def check_ci_status_and_approval(
         if not pr_for_commit:
             pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:
+            print(pr_for_commit)
             pr_number = pr_for_commit["number"]
             normalized_pr_title = util.normalize_title(
                 pr_for_commit["title"], pr_for_commit["body"]

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -132,7 +132,7 @@ async def check_ci_status_and_approval(
 
 async def merge_pr(gh, pr, sha, is_automerge=False):
     pr_number = pr["number"]
-    async for commit in gh.getiter(f"/repos/python/cpython/pulls/{pr_number}/commits"):
+    async for commit in gh.getiter(f"/repos/python/cpython/pulls/{pr_number}/commits"):  # pragma: no branch
         if commit["sha"] == sha:  # pragma: no branch
             if is_automerge:
                 pr_commit_msg = util.normalize_message(pr["body"])

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -118,7 +118,6 @@ async def check_ci_status_and_approval(
                     else:
                         emoji = "❌"
                         description = "failure"
-                    print("leaving a comment")
                     await util.leave_comment(
                         gh,
                         pr_number=pr_number,
@@ -134,7 +133,7 @@ async def check_ci_status_and_approval(
 async def merge_pr(gh, pr, sha, is_automerge=False):
     pr_number = pr["number"]
     async for commit in gh.getiter(f"/repos/python/cpython/pulls/{pr_number}/commits"):
-        if commit["sha"] == sha:
+        if commit["sha"] == sha:  # pragma: no branch
             if is_automerge:
                 pr_commit_msg = util.normalize_message(pr["body"])
                 pr_title = f"{pr['title']} (GH-{pr_number})"

--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -93,7 +93,6 @@ async def check_ci_status_and_approval(
         if not pr_for_commit:
             pr_for_commit = await util.get_pr_for_commit(gh, sha)
         if pr_for_commit:
-            print(pr_for_commit)
             pr_number = pr_for_commit["number"]
             normalized_pr_title = util.normalize_title(
                 pr_for_commit["title"], pr_for_commit["body"]

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -36,7 +36,7 @@ CHERRY_PICKER_CONFIG = {
 
 @app.task()
 def setup_cpython_repo():
-    print("Setting up CPython repository")
+    print("Setting up CPython repository") # pragma: nocover
     if "cpython" not in os.listdir("."):
         subprocess.check_output(
             f"git clone https://{os.environ.get('GH_AUTH')}:x-oauth-basic@github.com/miss-islington/cpython.git".split()

--- a/miss_islington/util.py
+++ b/miss_islington/util.py
@@ -110,7 +110,7 @@ async def is_core_dev(gh, username):
     org_teams = "/orgs/python/teams"
     team_name = "python core"
     async for team in gh.getiter(org_teams):
-        if team["name"].lower() == team_name:
+        if team["name"].lower() == team_name:  # pragma: no branch
             break
     else:
         raise ValueError(f"{team_name!r} not found at {org_teams!r}")

--- a/miss_islington/util.py
+++ b/miss_islington/util.py
@@ -133,7 +133,7 @@ def pr_is_awaiting_merge(pr_labels):
     if (
         "DO-NOT-MERGE" not in label_names
         and "awaiting merge" in label_names
-        and "CLA signed" in label_names
+        and "CLA not signed" not in label_names
     ):
         return True
     return False

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+
+[pytest]
+asyncio_mode=auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
-
 [pytest]
 asyncio_mode=auto

--- a/tests/test_backport_pr.py
+++ b/tests/test_backport_pr.py
@@ -58,7 +58,7 @@ async def test_labeled_on_merged_pr_no_backport_label():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues{/number}"
         },
-        "label": {"name": "CLA signed"},
+        "label": {"name": "skip news"},
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -89,7 +89,7 @@ async def test_merged_pr_no_backport_label():
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"}
+            {"name": "skip news"}
         ],
     }
 
@@ -121,7 +121,6 @@ async def test_merged_pr_with_backport_label(branch):
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"},
             {"name": f"needs backport to {branch}"},
         ],
     }
@@ -156,7 +155,6 @@ async def test_merged_pr_with_backport_label_thank_pr_author():
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"},
             {"name": "needs backport to 3.7"},
         ],
     }
@@ -190,7 +188,6 @@ async def test_easter_egg():
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"},
             {"name": "needs backport to 3.7"},
         ],
     }
@@ -236,7 +233,6 @@ async def test_backport_pr_redis_connection_error():
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"},
             {"name": "needs backport to 3.7"},
         ],
     }
@@ -269,7 +265,6 @@ async def test_backport_pr_kombu_operational_error():
             "labels_url": "https://api.github.com/repos/python/cpython/issues/1/labels{/name}"
         },
         "https://api.github.com/repos/python/cpython/issues/1/labels": [
-            {"name": "CLA signed"},
             {"name": "needs backport to 3.7"},
         ],
     }

--- a/tests/test_check_run.py
+++ b/tests/test_check_run.py
@@ -38,9 +38,7 @@ async def test_check_run_completed_ci_passed_with_awaiting_merge_label_pr_is_mer
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -48,7 +46,7 @@ async def test_check_run_completed_ci_passed_with_awaiting_merge_label_pr_is_mer
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -120,9 +118,7 @@ async def test_check_run_completed_other_check_run_pending_with_awaiting_merge_l
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -130,7 +126,7 @@ async def test_check_run_completed_other_check_run_pending_with_awaiting_merge_l
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -183,9 +179,7 @@ async def test_check_run_completed_other_check_run_queued_with_awaiting_merge_la
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -193,7 +187,7 @@ async def test_check_run_completed_other_check_run_queued_with_awaiting_merge_la
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -246,9 +240,7 @@ async def test_check_run_completed_failure_with_awaiting_merge_label_pr_is_not_m
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -256,7 +248,7 @@ async def test_check_run_completed_failure_with_awaiting_merge_label_pr_is_not_m
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -309,9 +301,7 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -319,7 +309,7 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -460,7 +450,6 @@ async def test_ci_passed_automerge():
             "merged_by": None,
             "labels": [
                 {"name": "awaiting merge"},
-                {"name": "CLA signed"},
                 {"name": AUTOMERGE_LABEL},
             ],
         },
@@ -474,7 +463,6 @@ async def test_ci_passed_automerge():
                     "labels": [
                         {"name": "awaiting merge"},
                         {"name": AUTOMERGE_LABEL},
-                        {"name": "CLA signed"},
                     ],
                 }
             ],
@@ -542,7 +530,7 @@ async def test_ci_passed_not_automerge():
         "/repos/python/cpython/pulls/5547": {
             "user": {"login": "bedevere-bot"},
             "merged_by": None,
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+            "labels": [{"name": "awaiting merge"}],
         },
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
@@ -551,7 +539,7 @@ async def test_ci_passed_not_automerge():
                     "number": 5547,
                     "title": "bpo-32720: Fixed the replacement field grammar documentation.",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -92,9 +92,7 @@ async def test_ci_passed_with_awaiting_merge_label_pr_is_merged():
             "user": {"login": "miss-islington"},
             "merged_by": {"login": "Mariatta"},
         },
-        "/repos/python/cpython/pulls/5547": {
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}]
-        },
+        "/repos/python/cpython/pulls/5547": {"labels": [{"name": "awaiting merge"}]},
         f"/search/issues?q=type:pr+repo:python/cpython+sha:{sha}": {
             "total_count": 1,
             "items": [
@@ -102,7 +100,7 @@ async def test_ci_passed_with_awaiting_merge_label_pr_is_merged():
                     "number": 5547,
                     "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
                     "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
-                    "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+                    "labels": [{"name": "awaiting merge"}],
                 }
             ],
         },
@@ -435,7 +433,7 @@ async def test_awaiting_merge_label_added_and_ci_passed_pr_is_merged():
         "action": "labeled",
         "pull_request": {
             "user": {"login": "miss-islington"},
-            "labels": [{"name": "awaiting merge"}, {"name": "CLA signed"}],
+            "labels": [{"name": "awaiting merge"}],
             "head": {"sha": sha},
             "number": 5547,
             "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
@@ -465,15 +463,8 @@ async def test_awaiting_merge_label_added_and_ci_passed_pr_is_merged():
             ],
         },
         f"/repos/python/cpython/commits/{sha}/check-runs": {
-            "check_runs": [
-                {
-                    "conclusion": "success",
-                    "name": "Travis CI - Pull Request",
-                    "status": "completed",
-                },
-                {"conclusion": "success", "name": "Docs", "status": "completed"},
-            ],
-            "total_count": 1,
+            "check_runs": [],
+            "total_count": 0,
         },
     }
 
@@ -511,6 +502,9 @@ async def test_awaiting_merge_webhook_ci_failure_pr_is_not_merged():
             "user": {"login": "miss-islington"},
             "labels": [{"name": "awaiting merge"}],
             "head": {"sha": sha},
+            "number": 5547,
+            "title": "[3.6] bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)",
+            "body": "\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>",
         },
         "sender": {"login": "Mariatta"},
         "label": {"name": "awaiting merge"},
@@ -546,6 +540,16 @@ async def test_awaiting_merge_webhook_ci_failure_pr_is_not_merged():
                     "labels": [{"name": "awaiting merge"}],
                 }
             ],
+        },
+        f"/repos/python/cpython/commits/{sha}/check-runs": {
+            "check_runs": [
+                {
+                    "conclusion": "failure",
+                    "name": "Travis CI - Pull Request",
+                    "status": "completed",
+                }
+            ],
+            "total_count": 1,
         },
     }
 
@@ -1183,7 +1187,6 @@ async def test_ci_passed_automerge():
             "merged_by": None,
             "labels": [
                 {"name": "awaiting merge"},
-                {"name": "CLA signed"},
                 {"name": AUTOMERGE_LABEL},
             ],
         },
@@ -1197,7 +1200,6 @@ async def test_ci_passed_automerge():
                     "labels": [
                         {"name": "awaiting merge"},
                         {"name": AUTOMERGE_LABEL},
-                        {"name": "CLA signed"},
                     ],
                 }
             ],
@@ -1301,7 +1303,6 @@ async def test_awaiting_merge_label_and_automerge_label_added_not_miss_islington
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1458,7 +1459,6 @@ async def test_automerge_multi_commits_in_pr():
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1535,7 +1535,6 @@ async def test_automerge_commit_not_found():
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1599,7 +1598,6 @@ async def test_automerge_failed():
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1685,7 +1683,6 @@ async def test_automerge_label_added_by_non_core_dev():
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1747,7 +1744,6 @@ async def test_automerge_label_triggered_by_added_to_pr():
             "labels": [
                 {"name": "awaiting merge"},
                 {"name": AUTOMERGE_LABEL},
-                {"name": "CLA signed"},
             ],
             "head": {"sha": sha},
             "number": 5547,
@@ -1803,5 +1799,3 @@ async def test_automerge_label_triggered_by_added_to_pr():
     assert gh.patch_data == {
         "body": f"{data['pull_request']['body']}\n\nAutomerge-Triggered-By: GH:Mariatta"
     }
-
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -84,7 +84,8 @@ def test_message_normalization():
     message = "\r\nParts <!--comment--> we want\r\nincluded"
     assert util.normalize_message(message) == "\n\nParts  we want\r\nincluded"
 
-    message = textwrap.dedent("""
+    message = textwrap.dedent(
+        """
     The truncate() method of io.BufferedReader() should raise
     UnsupportedOperation when it is called on a read-only
     io.BufferedReader() instance.
@@ -98,15 +99,18 @@ def test_message_normalization():
     
     
     Automerge-Triggered-By: @methane
-    """)
+    """
+    )
 
-    expected_message = textwrap.dedent("""
+    expected_message = textwrap.dedent(
+        """
 
     The truncate() method of io.BufferedReader() should raise
     UnsupportedOperation when it is called on a read-only
     io.BufferedReader() instance.
     
-    Automerge-Triggered-By: @methane""")
+    Automerge-Triggered-By: @methane"""
+    )
     assert util.normalize_message(message) == expected_message
 
 
@@ -221,13 +225,12 @@ async def test_is_core_dev():
 
 
 def test_pr_is_awaiting_merge():
-    labels = [{"name": "CLA signed"}, {"name": "awaiting merge"}]
+    labels = [{"name": "awaiting merge"}]
     assert util.pr_is_awaiting_merge(labels) is True
 
 
 def test_pr_is_do_not_merge():
     labels = [
-        {"name": "CLA signed"},
         {"name": "awaiting merge"},
         {"name": "DO-NOT-MERGE"},
     ]
@@ -246,7 +249,6 @@ def test_pr_is_do_not_merge():
 
 def test_pr_is_automerge():
     labels = [
-        {"name": "CLA signed"},
         {"name": util.AUTOMERGE_LABEL},
         {"name": "awaiting review"},
     ]
@@ -255,7 +257,6 @@ def test_pr_is_automerge():
 
 def test_pr_is_not_awaiting_merge():
     labels = [
-        {"name": "CLA signed"},
         {"name": "skip issue"},
         {"name": "awaiting review"},
     ]
@@ -263,7 +264,7 @@ def test_pr_is_not_awaiting_merge():
 
 
 def test_pr_is_not_automerge():
-    labels = [{"name": "CLA signed"}, {"name": "awaiting merge"}]
+    labels = [{"name": "awaiting merge"}]
     assert util.pr_is_automerge(labels) is False
 
 


### PR DESCRIPTION
CPython is now using cpython-cla-bot, and we're not relying on the CLA Signed label anymore.
CLA signed is now a status check on the CI.

Also remove the DeprecationWarning from pytest by adding pytest.ini