### PR TITLE
Fix status check comment for timed out or failed checks

### DIFF
--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -139,9 +139,7 @@ async def check_ci_status_and_approval(
 
 async def merge_pr(gh, pr, sha, is_automerge=False):
     pr_number = pr["number"]
-    async for commit in gh.getiter(
-        f"/repos/python/cpython/pulls/{pr_number}/commits"
-    ):  # pragma: no branch
+    async for commit in gh.getiter(f"/repos/python/cpython/pulls/{pr_number}/commits"):  # pragma: no branch
         if commit["sha"] == sha:  # pragma: no branch
             if is_automerge:
                 pr_commit_msg = util.normalize_message(pr["body"])

--- a/tests/test_check_run.py
+++ b/tests/test_check_run.py
@@ -143,7 +143,18 @@ async def test_check_run_completed_other_check_run_pending_with_awaiting_merge_l
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
     assert not hasattr(gh, "post_data")  # does not leave a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -326,7 +337,18 @@ async def test_check_run_completed_timed_out_with_awaiting_merge_label_pr_is_not
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await check_run.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -307,7 +307,18 @@ async def test_ci_passed_and_check_run_failure_awaiting_merge_label_pr_is_not_me
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -374,7 +385,18 @@ async def test_automerge_with_check_run_failure():
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -431,7 +453,18 @@ async def test_ci_passed_and_check_run_pending_awaiting_merge_label_pr_is_not_me
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
     assert len(gh.post_data["body"]) is not None  # leaves a comment
     assert not hasattr(gh, "put_data")  # is not merged
@@ -488,9 +521,23 @@ async def test_ci_passed_and_check_run_timed_out_awaiting_merge_label_pr_is_not_
         },
     }
 
-    gh = FakeGH(getitem=getitem)
+    getiter = {
+        "/repos/python/cpython/pulls/5547/commits": [
+            {
+                "sha": "f2393593c99dd2d3ab8bfab6fcc5ddee540518a9",
+                "commit": {
+                    "message": "bpo-32720: Fixed the replacement field grammar documentation. (GH-5544)\n\n`arg_name` and `element_index` are defined as `digit`+ instead of `integer`.\n(cherry picked from commit 7a561afd2c79f63a6008843b83733911d07f0119)\n\nCo-authored-by: Mariatta <Mariatta@users.noreply.github.com>"
+                },
+            }
+        ]
+    }
+
+    gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    assert (
+        gh.post_data["body"]
+        == "Status check is done, and it's a failure or timed out ❌."
+    )
     assert not hasattr(gh, "put_data")  # is not merged
 
 

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -2,7 +2,6 @@ import http
 
 import gidgethub
 from gidgethub import sansio
-
 from miss_islington import status_change
 from miss_islington.util import AUTOMERGE_LABEL
 
@@ -536,7 +535,7 @@ async def test_ci_passed_and_check_run_timed_out_awaiting_merge_label_pr_is_not_
     await status_change.router.dispatch(event, gh)
     assert (
         gh.post_data["body"]
-        == "Status check is done, and it's a failure or timed out ❌."
+        == "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
     )
     assert not hasattr(gh, "put_data")  # is not merged
 

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -534,10 +534,9 @@ async def test_ci_passed_and_check_run_timed_out_awaiting_merge_label_pr_is_not_
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert (
-        gh.post_data["body"]
-        == "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
-    )
+    expected_body = ("@miss-islington and @Mariatta: Status check is done, "
+                      "and it's a failure or timed out ❌.")
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -2,6 +2,7 @@ import http
 
 import gidgethub
 from gidgethub import sansio
+
 from miss_islington import status_change
 from miss_islington.util import AUTOMERGE_LABEL
 


### PR DESCRIPTION
Closes #564.

Split out the `"succes"` check from the timed out check so we can record both states.