### PR TITLE
Dependabot: switch to monthly frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: pytest-asyncio


### PR DESCRIPTION
Monthly means things don't get too out of date, and will be less noisy.

Docs:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#frequency-of-dependabot-pull-requests