### PR TITLE
Fix faulty logic for success/failure comment

### DIFF
--- a/miss_islington/status_change.py
+++ b/miss_islington/status_change.py
@@ -106,15 +106,15 @@ async def check_ci_status_and_approval(
                 )
                 success = result["state"] == "success" and not failure
                 if leave_comment:
-                    if success:
-                        emoji = "✅"
-                        status = "it's a success"
                     if failure:
                         emoji = "❌"
                         status = "it's a failure or timed out"
-                    else:
+                    elif not success:
                         emoji = "❌"
                         status = "it's a failure"
+                    else:
+                        emoji = "✅"
+                        status = "it's a success"
                     message = f"Status check is done, and {status} {emoji}."
                     if not success:
                         if is_automerge:

--- a/tests/test_status_change.py
+++ b/tests/test_status_change.py
@@ -129,7 +129,8 @@ async def test_ci_passed_with_awaiting_merge_label_pr_is_merged():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (
@@ -196,7 +197,8 @@ async def test_ci_and_check_run_passed_with_no_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -252,7 +254,8 @@ async def test_ci_not_passed_awaiting_merge_label_pr_is_not_merged():
 
     gh = FakeGH(getitem=getitem)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -320,7 +323,8 @@ async def test_ci_passed_and_check_run_failure_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -398,7 +402,8 @@ async def test_automerge_with_check_run_failure():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -466,7 +471,8 @@ async def test_ci_passed_and_check_run_pending_awaiting_merge_label_pr_is_not_me
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "@miss-islington and @Mariatta: Status check is done, and it's a failure or timed out ❌."
+    assert gh.post_data["body"] == expected_body
     assert not hasattr(gh, "put_data")  # is not merged
 
 
@@ -1342,7 +1348,8 @@ async def test_ci_passed_automerge():
 
     gh = FakeGH(getitem=getitem, getiter=getiter)
     await status_change.router.dispatch(event, gh)
-    assert len(gh.post_data["body"]) is not None  # leaves a comment
+    expected_body = "Status check is done, and it's a success ✅."
+    assert gh.post_data["body"] == expected_body
     assert gh.put_data["sha"] == sha  # is merged
     assert gh.put_data["merge_method"] == "squash"
     assert (


### PR DESCRIPTION
Refs https://github.com/python/miss-islington/pull/565#issuecomment-1237431097

The logic introduced in https://github.com/python/miss-islington/pull/565 was not correct as the `if ... if ... else` was place incorrectly.
I didn't catch this as the previous tests don't actually test for the actual message being commented, but only check if a comment is being posted. This fixes this and updates all test that check for comment posting in the `status_change` tests.

Pinging @ezio-melotti for a review.

Sorry for the confusion caused! I should have seen this gap in the tests when I first worked on this issue.