### PR TITLE
Remove `codecov`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,3 @@ pytest==7.2.2
 pytest-asyncio==0.21.0
 pytest-aiohttp==1.0.4
 pytest-cov==4.0.0
-codecov==2.1.12


### PR DESCRIPTION
We're using a GitHub action and this package is not usable anymore.