### PR TITLE
Add Python 3.12 to the CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]  # see #590 for "3.12"
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.5
 gidgethub==5.3.0
 cachetools==5.3.1
 redis==5.0.0
-celery==5.3.3
+celery==5.3.4
 sentry-sdk==1.30.0
 click==8.1.7
 


### PR DESCRIPTION
This PR is a follow-up of #590 and adds 3.12 to the CI workflow.  3.12 however is still failing, so we will have to wait until some upstream issues are fixed before merging:
* [ ] aiohttp https://github.com/aio-libs/aiohttp/issues/7229
* [x] yarl https://github.com/aio-libs/yarl/issues/829
* [X] frozenlist https://github.com/aio-libs/frozenlist/issues/433