### PR TITLE
Simplify CI config for caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,17 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             dev-requirements.txt
-      - run: python3 -m pip install -U -r dev-requirements.txt
-      - run: pytest --cov=. --cov-report=xml
+      - name: Install tox
+        run: |
+          python -m pip install tox
+      - name: Run Tests
+        env:
+          # run against the current Python interpreter
+          TOXENV: python
+        run: tox
       - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-
+          flags: Python_${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,27 @@
 name: Tests
 
-on:
-  pull_request:
-  push:
-    branches: main
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
   test:
     name: test w/ Python ${{ matrix.python-version }}
-
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]  # see #590 for "3.12"
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          cache: pip
+          cache-dependency-path: "*requirements.txt"
       - run: python3 -m pip install -U -r dev-requirements.txt
       - run: pytest --cov=. --cov-report=xml
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: "*requirements.txt"
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
       - run: python3 -m pip install -U -r dev-requirements.txt
       - run: pytest --cov=. --cov-report=xml
       - uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,91 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+.venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
 # virtualenv
 venv/
 ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+.pytest_cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist = py{312, 311, 310, 39}
-toxworkdir={env:TOX_WORK_DIR:.tox}
+toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 passenv =
     FORCE_COLOR
 skip_install = True
 deps =
-	-r dev-requirements.txt
+    -r dev-requirements.txt
 commands =
-	pytest --cov=. --cov-report=xml {posargs}
+    pytest --cov=. --cov-report=xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{312, 311, 310, 39}
+toxworkdir={env:TOX_WORK_DIR:.tox}
+
+[testenv]
+passenv =
+    FORCE_COLOR
+skip_install = True
+deps =
+	-r dev-requirements.txt
+commands =
+	pytest --cov=. --cov-report=xml {posargs}


### PR DESCRIPTION
Instead of explicitly using https://github.com/actions/cache, we can use the caching now built into https://github.com/actions/setup-python: https://github.com/actions/setup-python#caching-packages-dependencies

Also:

* Allow testing feature branches and triggers via the UI
* Use `fail-fast: false` so if one fails, allow the others to complete. Helps debugging - did a single job fail, or do all fail?
* Enable colour for more readable test output

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/1324225/235712626-02a05ef3-4eb8-4a79-a089-567626459c7d.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/1324225/235712661-56194130-7a86-48c9-92c9-98630210634d.png)

</details>