### PR TITLE
Bump celery to 5.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.5
 gidgethub==5.3.0
 cachetools==5.3.1
 redis==5.0.0
-celery==5.3.3
+celery==5.3.4
 sentry-sdk==1.30.0
 click==8.1.7
 


### PR DESCRIPTION
To fix the build for 3.9-3.11:

https://github.com/python/miss-islington/actions/runs/6336037275/job/17208313322