### PR TITLE
Dedent text to make code blocks copyable

### DIFF
--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -91,12 +91,13 @@ async def backport_task_asyncio(
                 await util.comment_on_pr(
                     gh,
                     issue_number,
-                    f"""{util.get_participants(created_by, merged_by)}, I can't backport for now.  Please try again later or
-                                   backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
-                                   ```
-                                   cherry_picker {commit_hash} {branch}
-                                   ```
-                                   """,
+                    f"""\
+                    {util.get_participants(created_by, merged_by)}, I can't backport for now.  Please try again later or
+                    backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
+                    ```
+                    cherry_picker {commit_hash} {branch}
+                    ```
+                    """,
                 )
                 await util.assign_pr_to_core_dev(gh, issue_number, merged_by)
 
@@ -117,13 +118,14 @@ async def backport_task_asyncio(
             await util.comment_on_pr(
                 gh,
                 issue_number,
-                f"""Sorry {util.get_participants(created_by, merged_by)}, I had trouble checking out the `{branch}` backport branch.
-                                Please retry by removing and re-adding the "needs backport to {branch}" label.
-                                Alternatively, you can backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on the command line.
-                                ```
-                                cherry_picker {commit_hash} {branch}
-                                ```
-                                """,
+                f"""\
+                Sorry {util.get_participants(created_by, merged_by)}, I had trouble checking out the `{branch}` backport branch.
+                Please retry by removing and re-adding the "needs backport to {branch}" label.
+                Alternatively, you can backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on the command line.
+                ```
+                cherry_picker {commit_hash} {branch}
+                ```
+                """,
             )
             await util.assign_pr_to_core_dev(gh, issue_number, merged_by)
             cp.abort_cherry_pick()
@@ -131,12 +133,13 @@ async def backport_task_asyncio(
             await util.comment_on_pr(
                 gh,
                 issue_number,
-                f"""Sorry, {util.get_participants(created_by, merged_by)}, I could not cleanly backport this to `{branch}` due to a conflict. 
-                                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
-                                ```
-                                cherry_picker {commit_hash} {branch}
-                                ```
-                                """,
+                f"""\
+                Sorry, {util.get_participants(created_by, merged_by)}, I could not cleanly backport this to `{branch}` due to a conflict.
+                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
+                ```
+                cherry_picker {commit_hash} {branch}
+                ```
+                """,
             )
             await util.assign_pr_to_core_dev(gh, issue_number, merged_by)
             cp.abort_cherry_pick()

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -36,7 +36,7 @@ CHERRY_PICKER_CONFIG = {
 
 @app.task()
 def setup_cpython_repo():
-    print("Setting up CPython repository") # pragma: nocover
+    print("Setting up CPython repository")  # pragma: nocover
     if "cpython" not in os.listdir("."):
         subprocess.check_output(
             f"git clone https://{os.environ.get('GH_AUTH')}:x-oauth-basic@github.com/miss-islington/cpython.git".split()
@@ -99,7 +99,7 @@ async def backport_task_asyncio(
                                    """,
                 )
                 await util.assign_pr_to_core_dev(gh, issue_number, merged_by)
-        
+
         # Ensure that we don't have any changes lying around
         subprocess.check_output(['git', 'reset', '--hard'])
         subprocess.check_output(['git', 'clean', '-fxd'])

--- a/miss_islington/util.py
+++ b/miss_islington/util.py
@@ -79,4 +79,3 @@ def normalize_title(title, body):
     else:
         # Being paranoid in case \r\n is used.
         return title[:-1] + body[1:].partition("\r\n")[0]
-

--- a/miss_islington/util.py
+++ b/miss_islington/util.py
@@ -1,8 +1,5 @@
-import re
 import subprocess
-
-import gidgethub
-
+import textwrap
 
 
 async def comment_on_pr(gh, issue_number, message):
@@ -10,6 +7,7 @@ async def comment_on_pr(gh, issue_number, message):
     Leave a comment on a PR/Issue
     """
     issue_comment_url = f"/repos/python/cpython/issues/{issue_number}/comments"
+    message = textwrap.dedent(message)
     data = {"body": message}
     response = await gh.post(issue_comment_url, data=data)
     print(f"Commented at {response['html_url']}, message: {message}")


### PR DESCRIPTION
Miss Islington comments on PRs [like this](https://github.com/python/cpython/pull/109569#issuecomment-1728272109):

---

Sorry, @hugovk, I could not cleanly backport this to `3.11` due to a conflict. 
                                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
                                ```
                                cherry_picker 14cdefa667f211401c9dfab33c4695e80b4e5e95 3.11
                                ```
                                                                
---

As plaintext:

```
Sorry, @hugovk, I could not cleanly backport this to `3.11` due to a conflict. 
                                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
                                ```
                                cherry_picker 14cdefa667f211401c9dfab33c4695e80b4e5e95 3.11
                                ```
                                
```


If we dedent it:

``````

Sorry, @hugovk, I could not cleanly backport this to `3.11` due to a conflict. 
Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
```
cherry_picker 14cdefa667f211401c9dfab33c4695e80b4e5e95 3.11
```

``````                             

Then it renders more nicely:

---

Sorry, @hugovk, I could not cleanly backport this to `3.11` due to a conflict. 
Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
```
cherry_picker 14cdefa667f211401c9dfab33c4695e80b4e5e95 3.11
```

---

And note the little copy button on the right which makes it easy to copy the command for pasting into the terminal:

![image](https://github.com/python/miss-islington/assets/1324225/f35276d5-81a4-48a8-b66b-17fd2d4a0e4e)
![image](https://github.com/python/miss-islington/assets/1324225/3d8e6ee6-67c2-4e4d-ba51-0f8dcf46b3e8)
