### PR TITLE
Miss-islington as a GitHub App

### DIFF
--- a/miss_islington/__main__.py
+++ b/miss_islington/__main__.py
@@ -8,6 +8,8 @@ import cachetools
 from aiohttp import web
 from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import routing, sansio
+from gidgethub import apps
+
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
@@ -30,11 +32,20 @@ async def main(request):
         print("GH delivery ID", event.delivery_id, file=sys.stderr)
         if event.event == "ping":
             return web.Response(status=200)
-        oauth_token = os.environ.get("GH_AUTH")
         async with aiohttp.ClientSession() as session:
             gh = gh_aiohttp.GitHubAPI(
-                session, "python/cpython", oauth_token=oauth_token, cache=cache
+                session, "python/cpython", cache=cache
             )
+            # This path only works on GitHub App
+            installation_id = event.data["installation"]["id"]
+            installation_access_token = await apps.get_installation_access_token(
+                gh,
+                installation_id=installation_id,
+                app_id=os.environ.get("GH_APP_ID"),
+                private_key=os.environ.get("GH_PRIVATE_KEY")
+            )
+            gh.oauth_token = installation_access_token["token"]
+
             # Give GitHub some time to reach internal consistency.
             await asyncio.sleep(1)
             await router.dispatch(event, gh)
@@ -43,8 +54,6 @@ async def main(request):
                     f"""\
 GH requests remaining: {gh.rate_limit.remaining}/{gh.rate_limit.limit}, \
 reset time: {gh.rate_limit.reset_datetime:%b-%d-%Y %H:%M:%S %Z}, \
-oauth token length {len(oauth_token)}, \
-last 4 digits {oauth_token[-4:]}, \
 GH delivery ID {event.delivery_id} \
 """
                 )
@@ -54,6 +63,12 @@ GH delivery ID {event.delivery_id} \
     except Exception as exc:
         traceback.print_exc(file=sys.stderr)
         return web.Response(status=500)
+
+
+@router.register("installation", action="created")
+async def repo_installation_added(event, gh, *args, **kwargs):
+    # installation_id = event.data["installation"]["id"]
+    print(f"App installed by {event.data['installation']['account']['login']}, installation_id: {event.data['installation']['id']}")
 
 
 sentry_sdk.init(dsn=os.environ.get("SENTRY_DSN"), integrations=[AioHttpIntegration()])

--- a/miss_islington/backport_pr.py
+++ b/miss_islington/backport_pr.py
@@ -39,7 +39,7 @@ async def backport_pr(event, gh, *args, **kwargs):
             for label in pr_labels
             if label["name"].startswith("needs backport to")
         ]
-
+        installation_id = event.data["installation"]["id"]
         if branches:
             easter_egg = ""
             if random.random() < 0.1:
@@ -62,12 +62,12 @@ async def backport_pr(event, gh, *args, **kwargs):
 
             for branch in sorted_branches:
                 await kickoff_backport_task(
-                    gh, commit_hash, branch, issue_number, created_by, merged_by
+                    gh, commit_hash, branch, issue_number, created_by, merged_by, installation_id=installation_id
                 )
 
 
 async def kickoff_backport_task(
-    gh, commit_hash, branch, issue_number, created_by, merged_by
+    gh, commit_hash, branch, issue_number, created_by, merged_by, installation_id
 ):
     try:
         tasks.backport_task.delay(
@@ -76,6 +76,7 @@ async def kickoff_backport_task(
             issue_number=issue_number,
             created_by=created_by,
             merged_by=merged_by,
+            installation_id=installation_id
         )
     except (redis_ex.ConnectionError, kombu_ex.OperationalError) as ex:
         err_message = f"I'm having trouble backporting to `{branch}`. Reason: '`{ex}`'. Please retry by removing and re-adding the `needs backport to {branch}` label."

--- a/tests/test_backport_pr.py
+++ b/tests/test_backport_pr.py
@@ -59,6 +59,7 @@ async def test_labeled_on_merged_pr_no_backport_label():
             "issues_url": "https://api.github.com/repos/python/cpython/issues{/number}"
         },
         "label": {"name": "skip news"},
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -81,6 +82,7 @@ async def test_merged_pr_no_backport_label():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -113,6 +115,7 @@ async def test_merged_pr_with_backport_label(branch):
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -147,6 +150,7 @@ async def test_merged_pr_with_backport_label_thank_pr_author():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -180,6 +184,7 @@ async def test_easter_egg():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -225,6 +230,7 @@ async def test_backport_pr_redis_connection_error():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 
@@ -257,6 +263,7 @@ async def test_backport_pr_kombu_operational_error():
         "repository": {
             "issues_url": "https://api.github.com/repos/python/cpython/issues/1"
         },
+        "installation": {"id": "123"}
     }
     event = sansio.Event(data, event="pull_request", delivery_id="1")
 


### PR DESCRIPTION
Use Installation Access Token instead of Personal Access token.

Note that the Personal Access Token is still needed during cherry-picking/backport process, as there is no GitHub API for cherry-picking.


Deployment tasks:

- [x] Choose a name for the GitHub App. 
- [x] Create a GitHub App under the Python org 
- [x] Assign @Mariatta app manager role on app
- [x] Set environment variables in miss-islington's Heroku app: `GH_APP_ID`, `GH_PRIVATE_KEY` (from the newly created GitHub App in the previous step)
- [ ] Deploy and test