### PR TITLE
Remove workaround from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ redis==5.0.1
 celery==5.3.6
 sentry-sdk==1.38.0
 click==8.1.7
-
-# workaround for celery/kombu#1600
-kombu==5.3.4; python_version>="3.12"


### PR DESCRIPTION
This workaround was added to deal with:
* https://github.com/celery/kombu/issues/1600

The issue is now fixed, so it should be safe to remove it.