### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@ updates:
     interval: monthly
   assignees:
     - "ezio-melotti"
-  open-pull-requests-limit: 10
+    groups:
+      pip:
+        patterns:
+          - "*"
 
 - package-ecosystem: "github-actions"
   directory: "/"
@@ -14,4 +17,7 @@ updates:
     interval: monthly
   assignees:
     - "ezio-melotti"
-  open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Open one grouped PR per month instead of many, to help deal with notification fatigue. 

Compare first two repos with the last:

<img width="1185" alt="image" src="https://github.com/python/bedevere/assets/1324225/c587ff53-85a9-4b2f-b20c-003ea127274b">
