### PR TITLE
Fix Dependabot grouping and validate YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-  assignees:
-    - "ezio-melotti"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "ezio-melotti"
     groups:
       pip:
         patterns:
           - "*"
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: monthly
-  assignees:
-    - "ezio-melotti"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "ezio-melotti"
     groups:
       actions:
         patterns:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: trailing-whitespace
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.1
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
+ci:
+  autoupdate_schedule: quarterly

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -175,4 +175,3 @@ async def test_assign_pr_to_coredev():
 
     await util.assign_pr_to_core_dev(gh, issue_number, coredev_login)
     assert gh.patch_url == f"/repos/python/cpython/issues/{issue_number}"
-


### PR DESCRIPTION
The grouping added in https://github.com/python/miss-islington/pull/686 didn't work: 

<img width="1190" alt="image" src="https://github.com/python/miss-islington/assets/1324225/854b0a91-c7d4-4b22-a6ea-3d21a582e1ef">

This was sue to invalid YAML.

Add validation via pre-commit and fix the indents.