### PR TITLE
Test Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # remember to update the envlist in tox.ini too
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312, 311}
+envlist = py{313, 312, 311}
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]


### PR DESCRIPTION
Pending CFFI support for 3.13, should be available in CFFI 1.17.0 soonish:

* https://github.com/python-cffi/cffi/issues/105