### PR TITLE
README: Remove outdated line about Python 3.6+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,6 @@ miss-islington
 
 Bot for backporting and merging `CPython <https://github.com/python/cpython/>`_ Pull Requests.
 
-miss-islington requires Python 3.6+.
-
 Backporting a PR on CPython
 ===========================
 


### PR DESCRIPTION
These README mentions are often forgotten.

We dropped 3.7 and 3.8 in 2021 (https://github.com/python/miss-islington/pull/478) and 3.9 and 3.10 in 2023 (https://github.com/python/miss-islington/pull/657).

See https://github.com/python/miss-islington/blob/main/runtime.txt and https://github.com/python/miss-islington/blob/main/.github/workflows/ci.yml for supported versions.