### PR TITLE
Acknowledge network issues from GitHub

### DIFF
--- a/miss_islington/delete_branch.py
+++ b/miss_islington/delete_branch.py
@@ -1,11 +1,14 @@
 import asyncio
 
+import gidgethub
 import gidgethub.routing
+import stamina
 
 router = gidgethub.routing.Router()
 
 
 @router.register("pull_request", action="closed")
+@stamina.retry(on=gidgethub.GitHubException, timeout=120)
 async def delete_branch(event, gh, *args, **kwargs):
     """
     Delete the branch once miss-islington's PR is closed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-cherry_picker==2.4.0
-#git+https://github.com/python/cherry-picker.git@remove-initial-state#egg=cherry_picker
+#cherry_picker==2.4.0
+git+https://github.com/python/cherry-picker.git@network-issues#egg=cherry_picker
 aiohttp==3.11.11
 gidgethub==5.3.0
 cachetools==5.5.0
 redis==5.2.1
 celery==5.4.0
 sentry-sdk==2.19.2
+stamina==24.3.0
 click==8.1.8


### PR DESCRIPTION
We quite regularly get failures due to sporadic GitHub network issues. This change introduces handling of a new `cherry_picker.GitHubException` to automatically abort and recover a sane state of the repository.

Previously, the repository was left in a PR_CREATING state, which was not expected by cherry-picker on a re-run, which made miss-islington stall until manually restarted.