### PR TITLE
cherry-picker 2.5.0 has been released

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -14,10 +14,11 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: forbid-submodules
+      - id: requirements-txt-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.1
+    rev: 0.31.0
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage
 pytest==8.3.4
-pytest-asyncio==0.25.0
 pytest-aiohttp==1.0.5
+pytest-asyncio==0.25.0
 pytest-cov==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-#cherry_picker==2.4.0
-git+https://github.com/python/cherry-picker.git@network-issues#egg=cherry_picker
+cherry_picker==2.5.0
 aiohttp==3.11.11
 gidgethub==5.3.0
 cachetools==5.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-cherry_picker==2.5.0
 aiohttp==3.11.11
-gidgethub==5.3.0
 cachetools==5.5.0
-redis==5.2.1
 celery==5.4.0
+cherry_picker==2.5.0
+click==8.1.8
+gidgethub==5.3.0
+redis==5.2.1
 sentry-sdk==2.19.2
 stamina==24.3.0
-click==8.1.8


### PR DESCRIPTION
Followup to https://github.com/python/miss-islington/pull/710.

* https://pypi.org/project/cherry-picker/2.5.0/
* https://github.com/python/cherry-picker/releases/tag/cherry-picker-v2.5.0 

Also add requirements-txt-fixer to pre-commit.