### PR TITLE
Add link to devguide section on backporting in failure message

### DIFF
--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -198,7 +198,7 @@ async def backport_task_asyncio(
                 issue_number,
                 f"""\
                 Sorry, {util.get_participants(created_by, merged_by)}, I could not cleanly backport this to `{branch}` due to a conflict.
-                Please backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on command line.
+                Please backport manually with the [cherry_picker](https://pypi.org/project/cherry-picker/) tool, see the [Backporting merged changes](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) section in the Python developer's guide for more information.
                 ```
                 cherry_picker {commit_hash} {branch}
                 ```
@@ -223,7 +223,7 @@ async def backport_task_asyncio(
                 f"""\
                 Sorry {util.get_participants(created_by, merged_by)}, I had trouble completing the backport.
                 Please retry by removing and re-adding the "needs backport to {branch}" label.
-                Please backport backport using [cherry_picker](https://pypi.org/project/cherry-picker/) on the command line.
+                If that does not work, please backport manually with the [cherry_picker](https://pypi.org/project/cherry-picker/) tool, see the [Backporting merged changes](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) section in the Python developer's guide for more information.
                 ```
                 cherry_picker {commit_hash} {branch}
                 ```

--- a/miss_islington/tasks.py
+++ b/miss_islington/tasks.py
@@ -198,7 +198,8 @@ async def backport_task_asyncio(
                 issue_number,
                 f"""\
                 Sorry, {util.get_participants(created_by, merged_by)}, I could not cleanly backport this to `{branch}` due to a conflict.
-                Please backport manually with the [cherry_picker](https://pypi.org/project/cherry-picker/) tool, see the [Backporting merged changes](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) section in the Python developer's guide for more information.
+
+                Please backport manually with [cherry_picker](https://pypi.org/project/cherry-picker/), see the [devguide](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) for more information.
                 ```
                 cherry_picker {commit_hash} {branch}
                 ```
@@ -222,8 +223,9 @@ async def backport_task_asyncio(
                 issue_number,
                 f"""\
                 Sorry {util.get_participants(created_by, merged_by)}, I had trouble completing the backport.
+
                 Please retry by removing and re-adding the "needs backport to {branch}" label.
-                If that does not work, please backport manually with the [cherry_picker](https://pypi.org/project/cherry-picker/) tool, see the [Backporting merged changes](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) section in the Python developer's guide for more information.
+                If that does not work, please backport manually with [cherry_picker](https://pypi.org/project/cherry-picker/), see the [devguide](https://devguide.python.org/getting-started/git-boot-camp/#backporting-merged-changes) for more information.
                 ```
                 cherry_picker {commit_hash} {branch}
                 ```


### PR DESCRIPTION
This adds a link to the devguide section on manual backporting (it is soon to be revamped by https://github.com/python/devguide/pull/1819/changes). The Devguide describes the process in more detail, and will help contributors when we ask them to backport their PRs manually.